### PR TITLE
Fixes deprecated autoDeserialize in HikariCP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <build.number />
         <plugin.version>${project.version}-${build.number}</plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spigot.api.version>1.13</spigot.api.version>
+        <spigot.api.version>1.20</spigot.api.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:AddstarMC/craftconomy3.git</connection>
@@ -48,12 +48,12 @@
         <repository>
             <id>maven.addstar.com.au</id>
             <name>maven.addstar.com.au-releases</name>
-            <url>http://maven.addstar.com.au/artifactory/ext-release-local</url>
+            <url>https://maven.addstar.com.au/artifactory/ext-release-local</url>
         </repository>
         <snapshotRepository>
             <id>maven.addstar.com.au</id>
             <name>maven.addstar.com.au-snapshots</name>
-            <url>http://maven.addstar.com.au/artifactory/ext-snapshot-local</url>
+            <url>https://maven.addstar.com.au/artifactory/ext-snapshot-local</url>
         </snapshotRepository>
     </distributionManagement>
     <repositories>
@@ -69,14 +69,14 @@
     <!-- Addstar repos -->
     <repository>
         <id>addstar-repo</id>
-        <url>http://maven.addstar.com.au/artifactory/ext-release-local</url>
+        <url>https://maven.addstar.com.au/artifactory/ext-release-local</url>
         <snapshots>
             <enabled>false</enabled>
         </snapshots>
     </repository>
     <repository>
         <id>addstar-snapshot-repo</id>
-        <url>http://maven.addstar.com.au/artifactory/ext-snapshot-local</url>
+        <url>https://maven.addstar.com.au/artifactory/ext-snapshot-local</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
@@ -88,11 +88,11 @@
     <repository>
         <id>vault-repo</id>
         <name>Public Releases</name>
-        <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
+        <url>https://nexus.hc.to/content/repositories/pub_releases/</url>
     </repository>
         <repository>
             <id>Sonotype</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
     <dependencies>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version> 1.13.2-R0.1-SNAPSHOT</version>
+            <version> 1.20.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.30</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/MySQLEngine.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/MySQLEngine.java
@@ -43,7 +43,6 @@ public class MySQLEngine extends SQLStorageEngine {
         config.addDataSourceProperty("databaseName", Common.getInstance().getMainConfig().getString("System.Database.Db", "Craftconomy"));
         config.addDataSourceProperty("user", Common.getInstance().getMainConfig().getString("System.Database.Username", "root"));
         config.addDataSourceProperty("password", Common.getInstance().getMainConfig().getString("System.Database.Password", ""));
-        config.addDataSourceProperty("autoDeserialize", true);
         if (DripReporterLoader.isEnabled()) {
             if (DripReporterLoader.getApi() != null) {
                 try {

--- a/src/test/java/com/greatmancode/craftconomy3/TestCommandSender.java
+++ b/src/test/java/com/greatmancode/craftconomy3/TestCommandSender.java
@@ -28,6 +28,16 @@ public class TestCommandSender implements CommandSender {
     }
 
     @Override
+    public void sendMessage(UUID sender, String message) {
+
+    }
+
+    @Override
+    public void sendMessage(UUID sender, String... messages) {
+
+    }
+
+    @Override
     public void sendMessage(String[] strings) {
 
     }


### PR DESCRIPTION
`autoDeserialize` in HikariCP configs has become deprecated. This config option is only used for the driver to automatically detect and de-serialize objects stored in BLOB fields within a database, and is not a required field. 
A search through all of CC3 and there is no sign of BLOB fields. Storage in MySql is not in BLOB'd.
A few dependency updates included and addition of 2 @overide annotations to keep "Tests" working.

This has all been tested locally and on skyblock (starting completely fresh and creating MySql tables.